### PR TITLE
Windows support

### DIFF
--- a/README.org
+++ b/README.org
@@ -4,7 +4,7 @@
 #+export_file_name: ./doc/README.md
 #+author: 8dcc
 
-*Simple C/C++ library for detour hooking in linux.*
+*Simple C/C++ library for detour hooking in linux and windows.*
 
 #+TOC: headlines 2
 
@@ -13,9 +13,8 @@
 This library is for detour hooking. For more information on how it works, check
 out my [[https://8dcc.github.io/programming/detour-hooking.html][blog entry]]. It supports x64 and x86 architectures.
 
-Currently this library is for unix-like systems, but it should be easy to port
-to windows. As far as I know, you should only need to change the [[https://github.com/8dcc/libdetour/blob/40f7a8c46b018cd676d04908a0fcc5b679a87740/src/detour.c#L18-L30][protect_addr]]
-function. Feel free to [[https://github.com/8dcc/libdetour/pulls][submit a PR]] if you want to add this.
+Currently, this library supports both windows and unix-like systems, since the
+only OS-specific function is =protect_addr()=.
 
 This library was originally made for [[https://github.com/8dcc/hl-cheat][8dcc/hl-cheat]], but I ended up using it in
 multiple projects (like [[https://github.com/8dcc/devildaggers-re][8dcc/devildaggers-re]]). It was inspired by [[https://guidedhacking.com/threads/simple-linux-windows-detour-class.10580/][this OOP

--- a/src/libdetour.c
+++ b/src/libdetour.c
@@ -13,6 +13,8 @@
 #include <stdbool.h>
 #include <string.h>
 
+/*----------------------------------------------------------------------------*/
+
 /*
  * 64 bits:
  *   0:  48 b8 88 77 66 55 44    movabs rax, 0x1122334455667788
@@ -31,6 +33,8 @@ static uint8_t def_jmp_bytes[] = { 0x48, 0xB8, 0x00, 0x00, 0x00, 0x00,
                                    0x00, 0x00, 0x00, 0x00, 0xFF, 0xE0 };
 #define JMP_BYTES_OFF 2 /* Offset inside the array where the ptr should go */
 #endif
+
+/*----------------------------------------------------------------------------*/
 
 #ifdef __unix__
 #include <unistd.h>   /* sysconf() */
@@ -53,17 +57,18 @@ static bool protect_addr(void* ptr, bool enable_write) {
     return true;
 }
 #elif defined _WIN32
-#include <memoryapi.h>   /* VirtualProtect */
+#include <Windows.h> /* VirtualProtect */
 
 static bool protect_addr(void* ptr, bool enable_write) {
-    uint32_t old_flags;
-    uint32_t new_flags =
-      enable_write ? PAGE_EXECUTE_READWRITE : PAGE_EXECUTE_READ;
-    return !VirtualProtect(ptr, sizeof(def_jmp_bytes), new_flags, &old_flags);
+    DWORD old_flags;
+    DWORD new_flags = enable_write ? PAGE_EXECUTE_READWRITE : PAGE_EXECUTE_READ;
+    return VirtualProtect(ptr, sizeof(def_jmp_bytes), new_flags, &old_flags);
 }
 #else
 #error "libdetour: This systems is not supported"
 #endif
+
+/*----------------------------------------------------------------------------*/
 
 void detour_init(detour_ctx_t* ctx, void* orig, void* hook) {
     ctx->detoured = false;

--- a/src/libdetour.c
+++ b/src/libdetour.c
@@ -6,31 +6,12 @@
  * https://github.com/8dcc/libdetour
  */
 
-#ifndef __unix__
-#error "libdetour: Non-unix systems are not supported"
-#endif
+/* NOTE: Remember to change this if you move the header */
+#include "detour.h"
 
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
-#include <unistd.h>   /* sysconf() */
-#include <sys/mman.h> /* mprotect() */
-
-/* NOTE: Remember to change this if you move the header */
-#include "detour.h"
-
-static bool protect_addr(void* ptr, int new_flags) {
-    long page_size      = sysconf(_SC_PAGESIZE);
-    long page_mask      = ~(page_size - 1);
-    uintptr_t next_page = ((uintptr_t)ptr + page_size - 1) & page_mask;
-    uintptr_t prev_page = next_page - page_size;
-    void* page          = (void*)prev_page;
-
-    if (mprotect(page, page_size, new_flags) == -1)
-        return false;
-
-    return true;
-}
 
 /*
  * 64 bits:
@@ -49,6 +30,39 @@ static uint8_t def_jmp_bytes[] = { 0xB8, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xE0 };
 static uint8_t def_jmp_bytes[] = { 0x48, 0xB8, 0x00, 0x00, 0x00, 0x00,
                                    0x00, 0x00, 0x00, 0x00, 0xFF, 0xE0 };
 #define JMP_BYTES_OFF 2 /* Offset inside the array where the ptr should go */
+#endif
+
+#ifdef __unix__
+#include <unistd.h>   /* sysconf() */
+#include <sys/mman.h> /* mprotect() */
+
+static bool protect_addr(void* ptr, bool enable_write) {
+    long page_size      = sysconf(_SC_PAGESIZE);
+    long page_mask      = ~(page_size - 1);
+    uintptr_t next_page = ((uintptr_t)ptr + page_size - 1) & page_mask;
+    uintptr_t prev_page = next_page - page_size;
+    void* page          = (void*)prev_page;
+
+    uint32_t new_flags = PROT_READ | PROT_EXEC;
+    if (enable_write)
+        new_flags |= PROT_WRITE;
+
+    if (mprotect(page, page_size, new_flags) == -1)
+        return false;
+
+    return true;
+}
+#elif defined _WIN32
+#include <memoryapi.h>   /* VirtualProtect */
+
+static bool protect_addr(void* ptr, bool enable_write) {
+    uint32_t old_flags;
+    uint32_t new_flags =
+      enable_write ? PAGE_EXECUTE_READWRITE : PAGE_EXECUTE_READ;
+    return !VirtualProtect(ptr, sizeof(def_jmp_bytes), new_flags, &old_flags);
+}
+#else
+#error "libdetour: This systems is not supported"
 #endif
 
 void detour_init(detour_ctx_t* ctx, void* orig, void* hook) {
@@ -76,14 +90,14 @@ bool detour_add(detour_ctx_t* ctx) {
         return true;
 
     /* See util.c */
-    if (!protect_addr(ctx->orig, PROT_READ | PROT_WRITE | PROT_EXEC))
+    if (!protect_addr(ctx->orig, true))
         return false;
 
     /* Copy our jmp instruction with our hook address to the orig */
     memcpy(ctx->orig, ctx->jmp_bytes, sizeof(ctx->jmp_bytes));
 
     /* Restore old protection */
-    if (!protect_addr(ctx->orig, PROT_READ | PROT_EXEC))
+    if (!protect_addr(ctx->orig, false))
         return false;
 
     ctx->detoured = true;
@@ -96,14 +110,14 @@ bool detour_del(detour_ctx_t* ctx) {
         return true;
 
     /* See util.c */
-    if (!protect_addr(ctx->orig, PROT_READ | PROT_WRITE | PROT_EXEC))
+    if (!protect_addr(ctx->orig, true))
         return false;
 
     /* Restore the bytes that were at the start of orig (we saved on init) */
     memcpy(ctx->orig, ctx->saved_bytes, sizeof(ctx->saved_bytes));
 
     /* Restore old protection */
-    if (!protect_addr(ctx->orig, PROT_READ | PROT_EXEC))
+    if (!protect_addr(ctx->orig, false))
         return false;
 
     ctx->detoured = false;


### PR DESCRIPTION
Add windows support by modifying `protect_addr()` depending on `__unix__` and `_WIN32` macros.